### PR TITLE
Add (shutdown-agents) so lein expectations does not hang for nearly a minute

### DIFF
--- a/src/leiningen/expectations.clj
+++ b/src/leiningen/expectations.clj
@@ -32,7 +32,8 @@
           (with-open [w# (-> (java.io.File. ~path)
                              (java.io.FileOutputStream.)
                              (java.io.OutputStreamWriter.))]
-            (.write w# (pr-str summary#)))))
+            (.write w# (pr-str summary#))))
+        (shutdown-agents))
      nil
      nil
      '(require ['expectations]))


### PR DESCRIPTION
After working with 0.0.2, I noticed that lein expectations would hang for up to a minute at the end of eval-in-project. This change adds a call to (shutdown-agents) so that eval-in-project returns quickly and lein expectations no longer hangs. If you could cut a 0.0.3 release with this change so we can update to that at World Singles, that would be much appreciated! Thanx, Sean.
